### PR TITLE
templates/frontend/components/ui: fix sonner toasterprops import issue

### DIFF
--- a/templates/frontend-react-router/app/components/ui/sonner.tsx
+++ b/templates/frontend-react-router/app/components/ui/sonner.tsx
@@ -1,12 +1,9 @@
-import { useTheme } from "next-themes"
-import { Toaster as Sonner, ToasterProps } from "sonner"
+import { Toaster as Sonner } from "sonner"
 
-const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme()
-
+const Toaster = ({ ...props }) => {
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme="system"
       className="toaster group"
       style={
         {


### PR DESCRIPTION
Modified sonner.tsx so that toasterprops does not show import issue anymore